### PR TITLE
Locale deDE and template Update

### DIFF
--- a/ImpBlizzardUI/loc/deDE.lua
+++ b/ImpBlizzardUI/loc/deDE.lua
@@ -1,62 +1,65 @@
---[[
-	Missing: Colourize Health Bars, Style Chat Bubbles, Hide Chat Arrows, Announce Interrupts
-]]
 
 local _, ImpBlizz = ...;
 
 if(GetLocale() == "deDE") then
+
     -- Micro Menu
-    ImpBlizz["Character"] = "Charakter";
-    ImpBlizz["Spellbook"] = "Zauberbuch";
-    ImpBlizz["Talents"] = "Talente";
+    ImpBlizz["Character"] = "Charakterinfo";
+    ImpBlizz["Spellbook"] = "Zauberbuch & Fähigkeiten";
+    ImpBlizz["Talents"] = "Spezialisierung & Talente";
     ImpBlizz["Achievements"] = "Erfolge";
-    ImpBlizz["Quest Log"] = "Quest Log";
+    ImpBlizz["Quest Log"] = "Questlog";
     ImpBlizz["Guild"] = "Gilde";
-    ImpBlizz["Group Finder"] = "Gruppensuche";
+    ImpBlizz["Group Finder"] = "Dungeonbrowser";
     ImpBlizz["Collections"] = "Sammlungen";
-    ImpBlizz["Dungeon Journal"] = "Dungeonkompendium";
-    ImpBlizz["Swap Bags"] = "Taschen";
-    ImpBlizz["ImpBlizzardUI"] = "Verbessertes Blizzard UI"
+    ImpBlizz["Dungeon Journal"] = "Abenteuerführer";
+    ImpBlizz["Swap Bags"] = "Taschenanzeige wechseln";
+    ImpBlizz["ImpBlizzardUI"] = "ImpBlizzardUI Einstellungen"
     ImpBlizz["Log Out"] = "Ausloggen";
-    ImpBlizz["Force Exit"] = "Verlassen erzwingen";
+    ImpBlizz["Force Exit"] = "Spiel verlassen";
 
     -- Merchant
-    ImpBlizz["Items Repaired from Guild Bank"] = "Items durch die Gildenbank repariert";
+    ImpBlizz["Items Repaired from Guild Bank"] = "Items mit der Gildenbank repariert";
     ImpBlizz["Can not Repair from Guild Bank"] = "Kann die Gildenbank nicht zum reparieren verwenden";
-    ImpBlizz["Items Repaired from Own Money"] = "Items durch das eigene Geld repariert";
+    ImpBlizz["Items Repaired from Own Money"] = "Items mit dem eigenen Geld repariert";
     ImpBlizz["Sold Trash Items"] = "Verkaufter Schrott";
 
     -- Combat
-    ImpBlizz[" killed "] = " getötet ";
+    ImpBlizz[" killed "] = " tötete ";
     ImpBlizz["Killing Blow!"] = "Todesstoß!";
-    ImpBlizz["HP < 50% !"] = "Gesundheit < 50% !";
-    ImpBlizz["HP < 25% !!!"] = "Gesundheit < 25% !!!";
+    ImpBlizz["HP < 50% !"] = "LP < 50% !"; -- LP - Lebenspunkte (shorter form)
+    ImpBlizz["HP < 25% !!!"] = "LP < 25% !!!";
 
     -- Config Headers
     ImpBlizz["Combat"] = "Kampf";
     ImpBlizz["Miscellaneous"] = "Sonstiges";
     ImpBlizz["User Interface"] = "Benutzeroberfläche";
+    ImpBlizz["PvP"] = "PvP";
+    ImpBlizz["Action Bars"] = "Aktionsleisten";
+    ImpBlizz["Chat"] = "Chat";
 
     -- Config Options
-    ImpBlizz["Display Class Icon"] = "Zeige Klassen Icons";
-    ImpBlizz["Display Health Warnings"] = "Zeige Gesundheits Warnungen";
+    ImpBlizz["Display Class Icon"] = "Zeige Klassenicons";
+    ImpBlizz["Display Health Warnings"] = "Zeige Gesundheitswarnungen";
     ImpBlizz["Display PvP Kill Tracker"] = "Zeige PVP Todeszähler";
-    ImpBlizz["Display Class Colours"] = "Zeige Klassenfarbe";
-    ImpBlizz["Auto Repair"] = "Automatisch Reparieren";
-    ImpBlizz["Use Guild Bank For Repairs"] = "Benutze die Gildenbank zum reparieren";
-    ImpBlizz["Auto Sell Trash"] = "Automatisch verkaufen von Schrott";
-    ImpBlizz["AFK Mode"] = "AFK Modus";
-    ImpBlizz["Display System Statistics"] = "Zeige Systemeinstellungen";
-    ImpBlizz["Display Player Co-Ordinates"] = "Zeige Spieler Koordinaten";
-    ImpBlizz["Display Art"] = "Zeige Verziehrungen";
-    ImpBlizz["Auto-Hide Quest Tracker"] = "Verstecke den Quest-Tracker Automatisch"
-    ImpBlizz["Highlight Killing Blows"] = "Hebe Todesstöße hervor"
-    ImpBlizz["PvP"] = "PvP"
-    ImpBlizz["Minify Blizzard Strings"] = "Verkleinere Blizzard Strings"
-    ImpBlizz["Style Chat"] = "Verschönere den Chat"
-    ImpBlizz["Action Bars"] = "Aktionsleisten"
-    ImpBlizz["Casting Bar Timer"] = "Zauberleisten Zeit"
-    ImpBlizz["Out of Range Indicator"] = "Außer Reichweiten Anzeige"
-    ImpBlizz["Hide Portrait Spam"] = "Verstäcke Portrait Spam"
+    ImpBlizz["Display Class Colours"] = "Zeige Klassenfarben";
+    ImpBlizz["Auto Repair"] = "Automatisch reparieren";
+    ImpBlizz["Use Guild Bank For Repairs"] = "Verwende die Gildenbank zum reparieren";
+    ImpBlizz["Auto Sell Trash"] = "Schrott automatisch verkaufen";
+    ImpBlizz["AFK Mode"] = "AFK Kamera Modus";
+    ImpBlizz["Display System Statistics"] = "Zeige Systemstatistiken";
+    ImpBlizz["Display Player Co-Ordinates"] = "Zeige Spielerkoordinaten";
+    ImpBlizz["Display Art"] = "Zeige Verzierungen (Greifen)";
+    ImpBlizz["Auto-Hide Quest Tracker"] = "Verstecke den Quest-Tracker automatisch";
+    ImpBlizz["Highlight Killing Blows"] = "Hebe Todesstöße hervor";
+    ImpBlizz["Minify Blizzard Strings"] = "Verkleinere Blizzard Texte im Chat";
+    ImpBlizz["Style Chat"] = "Verschönere den Chat";
+    ImpBlizz["Hide Chat Arrows"] = "Verstecke Chat Scrollpfeile";
+    ImpBlizz["Casting Bar Timer"] = "Zeige Zauberleisten Zeit";
+    ImpBlizz["Out of Range Indicator"] = "Reichweiten Anzeige";
+    ImpBlizz["Hide Portrait Spam"] = "Verstecke Portrait Spam";
+    ImpBlizz["Style Chat Bubbles"] = "Verschönere Sprechblasen";
+    ImpBlizz["Announce Interrupts"] = "Verkünde Unterbrechungszauber";
+    ImpBlizz["Colourize Health Bars"] = "Farbige Lebenspunktebalken";
 
 end

--- a/ImpBlizzardUI/loc/deDE.lua
+++ b/ImpBlizzardUI/loc/deDE.lua
@@ -12,7 +12,7 @@ if(GetLocale() == "deDE") then
     ImpBlizz["Guild"] = "Gilde";
     ImpBlizz["Group Finder"] = "Dungeonbrowser";
     ImpBlizz["Collections"] = "Sammlungen";
-    ImpBlizz["Dungeon Journal"] = "Abenteuerführer";
+    ImpBlizz["Adventure Guide"] = "Abenteuerführer";
     ImpBlizz["Swap Bags"] = "Taschenanzeige wechseln";
     ImpBlizz["ImpBlizzardUI"] = "ImpBlizzardUI Einstellungen"
     ImpBlizz["Log Out"] = "Ausloggen";

--- a/ImpBlizzardUI/loc/localisation_template.lua
+++ b/ImpBlizzardUI/loc/localisation_template.lua
@@ -13,7 +13,7 @@ if(GetLocale() == "localeHere") then
     ImpBlizz["Guild"] = "";
     ImpBlizz["Group Finder"] = "";
     ImpBlizz["Collections"] = "";
-    ImpBlizz["Dungeon Journal"] = "";
+    ImpBlizz["Adventure Guide"] = "";
     ImpBlizz["Swap Bags"] = "";
     ImpBlizz["ImpBlizzardUI"] = "";
     ImpBlizz["Log Out"] = "";

--- a/ImpBlizzardUI/loc/localisation_template.lua
+++ b/ImpBlizzardUI/loc/localisation_template.lua
@@ -15,7 +15,7 @@ if(GetLocale() == "localeHere") then
     ImpBlizz["Collections"] = "";
     ImpBlizz["Dungeon Journal"] = "";
     ImpBlizz["Swap Bags"] = "";
-    ImpBlizz["ImpBlizzardUI"] = ""
+    ImpBlizz["ImpBlizzardUI"] = "";
     ImpBlizz["Log Out"] = "";
     ImpBlizz["Force Exit"] = "";
 
@@ -35,6 +35,9 @@ if(GetLocale() == "localeHere") then
     ImpBlizz["Combat"] = "";
     ImpBlizz["Miscellaneous"] = "";
     ImpBlizz["User Interface"] = "";
+    ImpBlizz["PvP"] = ""; -- is used for Micro Menu ~and~ for Options Header
+    ImpBlizz["Action Bars"] = "";
+    ImpBlizz["Chat"] = "";
 
     -- Config Options
     ImpBlizz["Display Class Icon"] = "";
@@ -50,14 +53,14 @@ if(GetLocale() == "localeHere") then
     ImpBlizz["Display Art"] = "";
     ImpBlizz["Auto-Hide Quest Tracker"] = "";
     ImpBlizz["Highlight Killing Blows"] = "";
-    ImpBlizz["PvP"] = "";
     ImpBlizz["Minify Blizzard Strings"] = "";
     ImpBlizz["Style Chat"] = "";
     ImpBlizz["Hide Chat Arrows"] = "";
-    ImpBlizz["Action Bars"] = "";
     ImpBlizz["Casting Bar Timer"] = "";
     ImpBlizz["Out of Range Indicator"] = "";
     ImpBlizz["Hide Portrait Spam"] = "";
     ImpBlizz["Style Chat Bubbles"] = "";
+    ImpBlizz["Announce Interrupts"] = "";
+    ImpBlizz["Colourize Health Bars"] ="";
 
 end

--- a/ImpBlizzardUI/loc/ruRU.lua
+++ b/ImpBlizzardUI/loc/ruRU.lua
@@ -16,7 +16,7 @@ if( GetLocale() == "ruRU" )then
 	ImpBlizz["Guild"] = "Гильдия";
 	ImpBlizz["Group Finder"] = "Поиск группы";
 	ImpBlizz["Collections"] = "Коллекции";
-	ImpBlizz["Dungeon Journal"] = "Руководство Приключения";
+	ImpBlizz["Adventure Guide"] = "Руководство Приключения";
 	ImpBlizz["Swap Bags"] = "Переместить сумки";
 	ImpBlizz["Log Out"] = "Выход из мира";
 	ImpBlizz["Force Exit"] = "Выход из игры";

--- a/ImpBlizzardUI/modules/ImpBlizzardUI_Bars.lua
+++ b/ImpBlizzardUI/modules/ImpBlizzardUI_Bars.lua
@@ -263,7 +263,7 @@ local function UpdateMicroMenuList(newLevel)
     end
     table.insert(BarFrame.microMenuList, {text = "|cffFFFFFF"..ImpBlizz["Collections"], func = function() securecall(ToggleCollectionsJournal) end, notCheckable = true, fontObject = BarFrame.menuFont, icon = 'Interface\\MINIMAP\\TRACKING\\StableMaster' });
     if(newLevel >= 15) then
-        table.insert(BarFrame.microMenuList, {text = "|cffFFFFFF"..ImpBlizz["Adventure Guide"].."     ", func = function() securecall(ToggleEncounterJournal) end, notCheckable = true, fontObject = BarFrame.menuFont, icon = 'Interface\\MINIMAP\\TRACKING\\BattleMaster' });
+        table.insert(BarFrame.microMenuList, {text = "|cffFFFFFF"..ImpBlizz["Dungeon Journal"].."     ", func = function() securecall(ToggleEncounterJournal) end, notCheckable = true, fontObject = BarFrame.menuFont, icon = 'Interface\\MINIMAP\\TRACKING\\BattleMaster' });
     end
     table.insert(BarFrame.microMenuList, {text = "|cffFFFFFF"..ImpBlizz["Swap Bags"], func = function() ToggleBagBar() end, notCheckable = true, fontObject = BarFrame.menuFont, icon = 'Interface\\MINIMAP\\TRACKING\\Banker' });
     table.insert(BarFrame.microMenuList, {text = "|cff00FFFF"..ImpBlizz["ImpBlizzardUI"], func = function() InterfaceOptionsFrame_OpenToCategory("Improved Blizzard UI") end, notCheckable = true, fontObject = BarFrame.menuFont });

--- a/ImpBlizzardUI/modules/ImpBlizzardUI_Bars.lua
+++ b/ImpBlizzardUI/modules/ImpBlizzardUI_Bars.lua
@@ -263,7 +263,7 @@ local function UpdateMicroMenuList(newLevel)
     end
     table.insert(BarFrame.microMenuList, {text = "|cffFFFFFF"..ImpBlizz["Collections"], func = function() securecall(ToggleCollectionsJournal) end, notCheckable = true, fontObject = BarFrame.menuFont, icon = 'Interface\\MINIMAP\\TRACKING\\StableMaster' });
     if(newLevel >= 15) then
-        table.insert(BarFrame.microMenuList, {text = "|cffFFFFFF"..ImpBlizz["Dungeon Journal"].."     ", func = function() securecall(ToggleEncounterJournal) end, notCheckable = true, fontObject = BarFrame.menuFont, icon = 'Interface\\MINIMAP\\TRACKING\\BattleMaster' });
+        table.insert(BarFrame.microMenuList, {text = "|cffFFFFFF"..ImpBlizz["Adventure Guide"].."     ", func = function() securecall(ToggleEncounterJournal) end, notCheckable = true, fontObject = BarFrame.menuFont, icon = 'Interface\\MINIMAP\\TRACKING\\BattleMaster' });
     end
     table.insert(BarFrame.microMenuList, {text = "|cffFFFFFF"..ImpBlizz["Swap Bags"], func = function() ToggleBagBar() end, notCheckable = true, fontObject = BarFrame.menuFont, icon = 'Interface\\MINIMAP\\TRACKING\\Banker' });
     table.insert(BarFrame.microMenuList, {text = "|cff00FFFF"..ImpBlizz["ImpBlizzardUI"], func = function() InterfaceOptionsFrame_OpenToCategory("Improved Blizzard UI") end, notCheckable = true, fontObject = BarFrame.menuFont });


### PR DESCRIPTION
Hi, it's me again. Hope you are not tired of my pull requests already ;)

I just updated the deDE locale as I'm native speaker. I matched all the previous translated work from ben2k to the default used Blizzard strings, so a new user will recognize them faster. Also I added the options which have not been translated yet and updated the template accordingly.

You didn't use the Adventure Guide Key in your locales so I changed the old Dungeon Journal to Adventure Guide.

And I noticed, the ImpBlizz["PVP"] Key is used by the MicroMenu and the Options Header as well. So they are not treatet differently.