### PR TITLE
Re-position talking head frame when right action bar is enabled

### DIFF
--- a/ImpBlizzardUI/ImpBlizzardUI.toc
+++ b/ImpBlizzardUI/ImpBlizzardUI.toc
@@ -3,7 +3,8 @@
 ## Notes: General Improvements to the Default Blizzard UI
 ## Version: 1.7.2
 ## Author: Kaytotes
-## SavedVariables: Conf_Interrupts, Conf_ChatArrows, Conf_ClassIcon, Conf_ClassColours, Conf_HealthUpdate, Conf_ObjectiveTracker, Conf_KillingBlow, Conf_KillFeed, Conf_HideSpam, Conf_CastingTimer, Conf_AutoRepair, Conf_GuildBankRepair, Conf_SellGreys, Conf_AFKCamera, Conf_ShowCoords, Conf_ShowStats, Conf_StyleChat, Conf_MinifyGlobals, Conf_ShowArt, Conf_OutOfRange, Conf_HealthBarColor
+## SavedVariables: Conf_Interrupts, Conf_ChatArrows, Conf_ClassIcon, Conf_ClassColours, Conf_HealthUpdate, Conf_ObjectiveTracker, Conf_KillingBlow, Conf_KillFeed, Conf_HideSpam, Conf_CastingTimer, Conf_AutoRepair, Conf_GuildBankRepair, Conf_SellGreys, Conf_AFKCamera, Conf_ShowCoords, Conf_ShowStats, Conf_StyleChat, Conf_MinifyGlobals, Conf_ShowArt, Conf_OutOfRange, Conf_HealthBarColor, Conf_MoveTalkingHead
+## Dependencies: Blizzard_TalkingHeadUI
 
 loc.lua
 loc\ruRU.lua

--- a/ImpBlizzardUI/config.lua
+++ b/ImpBlizzardUI/config.lua
@@ -15,7 +15,7 @@ local HeaderFontSize = 13;
 
 -- Simply checks if any of the options have changed. This is basically a huge if statement
 local function ConfigChanged()
-    if(Conf_HealthBarColor ~= Config.panel.healthColour:GetChecked() or Conf_Interrupts ~= Config.panel.interrupts:GetChecked() or Conf_ChatArrows ~= Config.panel.chatArrows:GetChecked() or Conf_HealthUpdate ~= Config.panel.healthWarning:GetChecked() or Conf_ObjectiveTracker ~= Config.panel.objectiveTracker:GetChecked() or Conf_KillFeed ~= Config.panel.killFeed:GetChecked() or Conf_KillingBlow ~= Config.panel.killingBlow:GetChecked() or Conf_HideSpam ~= Config.panel.portraitSpam:GetChecked() or Conf_ClassColours ~= Config.panel.classColours:GetChecked() or Conf_ClassIcon ~= Config.panel.classIcon:GetChecked() or Conf_CastingTimer ~= Config.panel.castingBar:GetChecked() or Conf_OutOfRange ~= Config.panel.rangeIndicator:GetChecked() or Conf_ShowArt ~= Config.panel.barArt:GetChecked() or Conf_AutoRepair ~= Config.panel.autoRepair:GetChecked() or Conf_GuildBankRepair ~= Config.panel.guildRepair:GetChecked() or Conf_SellGreys ~= Config.panel.sellGreys:GetChecked() or Conf_AFKCamera ~= Config.panel.afkCamera:GetChecked() or Conf_ShowCoords ~= Config.panel.playerCoords:GetChecked() or Conf_ShowStats ~= Config.panel.systemStats:GetChecked() or Conf_MinifyGlobals ~= Config.panel.minifyStrings:GetChecked() or Conf_StyleChat ~= Config.panel.styleChat:GetChecked()) then
+    if(Conf_HealthBarColor ~= Config.panel.healthColour:GetChecked() or Conf_Interrupts ~= Config.panel.interrupts:GetChecked() or Conf_ChatArrows ~= Config.panel.chatArrows:GetChecked() or Conf_HealthUpdate ~= Config.panel.healthWarning:GetChecked() or Conf_ObjectiveTracker ~= Config.panel.objectiveTracker:GetChecked() or Conf_KillFeed ~= Config.panel.killFeed:GetChecked() or Conf_KillingBlow ~= Config.panel.killingBlow:GetChecked() or Conf_HideSpam ~= Config.panel.portraitSpam:GetChecked() or Conf_ClassColours ~= Config.panel.classColours:GetChecked() or Conf_ClassIcon ~= Config.panel.classIcon:GetChecked() or Conf_CastingTimer ~= Config.panel.castingBar:GetChecked() or Conf_OutOfRange ~= Config.panel.rangeIndicator:GetChecked() or Conf_ShowArt ~= Config.panel.barArt:GetChecked() or Conf_AutoRepair ~= Config.panel.autoRepair:GetChecked() or Conf_GuildBankRepair ~= Config.panel.guildRepair:GetChecked() or Conf_SellGreys ~= Config.panel.sellGreys:GetChecked() or Conf_AFKCamera ~= Config.panel.afkCamera:GetChecked() or Conf_ShowCoords ~= Config.panel.playerCoords:GetChecked() or Conf_ShowStats ~= Config.panel.systemStats:GetChecked() or Conf_MinifyGlobals ~= Config.panel.minifyStrings:GetChecked() or Conf_StyleChat ~= Config.panel.styleChat:GetChecked() or Conf_MoveTalkingHead ~= Config.panel.moveTalkingHead:GetChecked()) then
         return true;
     else
         return false;
@@ -48,6 +48,7 @@ local function SetDefaults_Primary()
     Config.panel.chatArrows:SetChecked(true);
     Config.panel.interrupts:SetChecked(true);
     Config.panel.healthColour:SetChecked(true);
+    Config.panel.moveTalkingHead:SetChecked(true);
 end
 
 -- Loads the already set config options for the Primary window
@@ -73,6 +74,7 @@ local function LoadConfig_Primary()
     Config.panel.chatArrows:SetChecked(Conf_ChatArrows);
     Config.panel.interrupts:SetChecked(Conf_Interrupts);
     Config.panel.healthColour:SetChecked(Conf_HealthBarColor);
+    Config.panel.moveTalkingHead:SetChecked(Conf_MoveTalkingHead);
 end
 
 -- Applies any changes
@@ -99,6 +101,7 @@ local function ApplyChanges_Primary()
         Conf_ChatArrows = Config.panel.chatArrows:GetChecked();
         Conf_Interrupts = Config.panel.interrupts:GetChecked();
         Conf_HealthBarColor = Config.panel.healthColour:GetChecked();
+        Conf_MoveTalkingHead = Config.panel.moveTalkingHead:GetChecked();
         ReloadUI();
     end
 end
@@ -126,6 +129,7 @@ local function CheckFirstLoad()
     if (Conf_ChatArrows == nil) then Conf_ChatArrows = true end
     if (Conf_Interrupts == nil) then Conf_Interrupts = true end
     if (Conf_HealthBarColor == nil) then Conf_HealthBarColor = true end
+    if (Conf_MoveTalkingHead == nil) then Conf_MoveTalkingHead = true end
 end
 
 -- Event Handler, Only used for detecting when the addon has finished initialising and trigger config loading
@@ -200,6 +204,7 @@ local function BuildWindow_Primary()
 
     createCheckBox("playerCoords", "Display Player Co-Ordinates", "Coords");
     createCheckBox("systemStats", "Display System Statistics", "Stats");
+    createCheckBox("moveTalkingHead", "Move Talking Head Frame", "MoveTalkingHead");
     --[[
         User Interface Config Ends
     ]]

--- a/ImpBlizzardUI/loc/localisation_template.lua
+++ b/ImpBlizzardUI/loc/localisation_template.lua
@@ -62,5 +62,6 @@ if(GetLocale() == "localeHere") then
     ImpBlizz["Style Chat Bubbles"] = "";
     ImpBlizz["Announce Interrupts"] = "";
     ImpBlizz["Colourize Health Bars"] ="";
+    ImpBlizz["Move Talking Head Frame"] ="";
 
 end

--- a/ImpBlizzardUI/modules/ImpBlizzardUI_Bars.lua
+++ b/ImpBlizzardUI/modules/ImpBlizzardUI_Bars.lua
@@ -28,6 +28,13 @@ local function ModifyBasicFrame(frame, anchor, parent, posX, posY, scale)
     if(scale ~= nil) then frame:SetScale(scale) end
 end
 
+-- Move the talking head frame up slightly so it doesn't clip with the bottom right action bar
+local function MoveTalkingHeadFrame()
+    TalkingHeadFrame.ignoreFramePositionManager = true;
+    TalkingHeadFrame:ClearAllPoints();
+    TalkingHeadFrame:SetPoint("BOTTOM", 0, 145);
+end
+
 local function AdjustExperienceBars()
     offset = 0;
 
@@ -160,6 +167,9 @@ local function AdjustActionBars()
         end
         if(MultiBarBottomRight:IsShown()) then
             ModifyFrame(StanceBarFrame, "TOPLEFT", nil, 0, 110 + offset, 1);
+            if(Conf_MoveTalkingHead) then
+                MoveTalkingHeadFrame();
+            end
         end
         if(MultiBarBottomLeft:IsShown() ~= true and MultiBarBottomRight:IsShown() ~= true) then
             ModifyFrame(StanceBarFrame, "TOPLEFT", nil, 0, 20 + offset, 1);


### PR DESCRIPTION
This just moves the talking head frame up about 10 pixels whenever the right action bar is enabled to prevent it from clipping with the bar. Here's a screenshot to demonstrate:

![no-clip-thf](https://user-images.githubusercontent.com/4049845/28096207-e5b80622-669e-11e7-960f-f4b8057dae4d.png)
