### PR TITLE
Fixed overlapping with order hall bar

### DIFF
--- a/ImpBlizzardUI/core.lua
+++ b/ImpBlizzardUI/core.lua
@@ -391,9 +391,9 @@ local function BuildOrderHallBar()
 	Core.OrderBar.resourcesText:SetPoint("CENTER", -200, 0);
 	Core.OrderBar.resourcesText:SetFont(CoreFont, 16, "THINOUTLINE");
 
-	-- Create the Order Hall Resources Text and Assign a Font
+	-- Create the Order Hall Troops Text and Assign a Font
 	Core.OrderBar.troopsText = Core.OrderBar:CreateFontString(nil, "OVERLAY", "GameFontNormal");
-	Core.OrderBar.troopsText:SetPoint("CENTER", 200, 0);
+	Core.OrderBar.troopsText:SetPoint("CENTER", 300, 0);
 	Core.OrderBar.troopsText:SetFont(CoreFont, 16, "THINOUTLINE");
 end
 


### PR DESCRIPTION
I've noticed that in patch 7.3 2 troops from Argus were added. This caused some overlap with the order hall location and the troop resource bar.

I've applied a simple fix of shifting the troop resources to the right by 100 pixels.

Before:
![wowscrnshot_092317_201732](https://user-images.githubusercontent.com/12175684/30778521-236cedde-a0a6-11e7-9236-3411463a8628.jpg)

After:
![wowscrnshot_092317_205922](https://user-images.githubusercontent.com/12175684/30778524-27198096-a0a6-11e7-878b-bb5c1f64f900.jpg)