### PR TITLE
handle minus creature type as trivial

### DIFF
--- a/modules/misc/tooltips.lua
+++ b/modules/misc/tooltips.lua
@@ -18,6 +18,7 @@ local backgroundColour = {
 };
 
 local unitClassification = {
+    minus = Loc['Trivial'],
     trivial = Loc['Trivial'],
     normal =  Loc['Normal'],
     rare = Loc['Rare'],


### PR DESCRIPTION
See "Needle Sprite" in Kun-Lai Summit, the classification is `minus`, figured they should probably just be trivial?


![image](https://user-images.githubusercontent.com/1013429/36594847-fea88ea6-18f3-11e8-8d1a-af919dae612b.png)
