### PR TITLE
(Fix) Minify strings option will now be used only when wanted

### DIFF
--- a/modules/misc/chat.lua
+++ b/modules/misc/chat.lua
@@ -302,7 +302,10 @@ end
     @ return void
 ]]
 function ImpUI_Chat:OnEnable()
-    ImpUI_Chat:OverrideStrings();
+    local minify = ImpUI.db.char.minifyStrings;
+    if (minify == true) then
+        ImpUI_Chat:OverrideStrings();    
+    end
     ImpUI_Chat:StyleChat();
 
     -- Apply Quality of Life changes that don't need to be toggled.


### PR DESCRIPTION
Should be self-explanatory. Small fix so that the toggle option in the config window actually has an effect for players who do not want the strings mini-fied.