### PR TITLE
Adjustable Talking Head Frame

### DIFF
--- a/ImprovedBlizzardUI.toc
+++ b/ImprovedBlizzardUI.toc
@@ -44,6 +44,7 @@ modules/frames/target/health.lua
 modules/frames/target/mana.lua
 modules/frames/party.lua
 modules/frames/focus.lua
+modules/frames/talkinghead.lua
 modules/bars/castbar.lua
 modules/bars/buffs.lua
 modules/bars/micromenu.lua

--- a/ImprovedBlizzardUI.toc
+++ b/ImprovedBlizzardUI.toc
@@ -6,7 +6,7 @@
 ## SavedVariables: ImpUI_DB
 ## OptionalDeps: Ace3
 ## X-Embeds: Ace3
-
+## Dependencies: Blizzard_TalkingHeadUI
 ## X-Curse-Project-ID: 103336
 ## X-WoWI-ID: 23299
 

--- a/ImprovedBlizzardUI.toc
+++ b/ImprovedBlizzardUI.toc
@@ -4,9 +4,8 @@
 ## Version: @project-version@
 ## Author: Kaytotes
 ## SavedVariables: ImpUI_DB
-## OptionalDeps: Ace3
+## OptionalDeps: Ace3, Blizzard_TalkingHeadUI
 ## X-Embeds: Ace3
-## Dependencies: Blizzard_TalkingHeadUI
 ## X-Curse-Project-ID: 103336
 ## X-WoWI-ID: 23299
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ This will require you to have the following:
 
 ## Miscellaneous
 
+* Customisable Talking Head Frame Position.
 * Guild Bank Repair Support.
 * Automatic Achievement Screenshot.
 * Replacement Order Hall Bar.

--- a/config.lua
+++ b/config.lua
@@ -121,7 +121,7 @@ ImpUI_Config.defaults = {
         showLeftText = true,
         showRightText = true,
 
-        talkingHeadPosition = Helpers.pack_position('TOP', UIParent, 'TOP', 0, 0),
+        talkingHeadPosition = Helpers.pack_position('TOP', UIParent, 'TOP', 0, -35),
     },
 };
 

--- a/config.lua
+++ b/config.lua
@@ -120,6 +120,8 @@ ImpUI_Config.defaults = {
         showBottomRightText = true,
         showLeftText = true,
         showRightText = true,
+
+        talkingHeadPosition = Helpers.pack_position('TOP', UIParent, 'TOP', 0, 0),
     },
 };
 

--- a/core.lua
+++ b/core.lua
@@ -39,6 +39,7 @@ local function GetDraggables()
 
     if (Helpers.IsRetail()) then
         table.insert(draggables, 'ImpUI_Focus');
+        table.insert(draggables, 'ImpUI_TalkingHead');
     end
 
     if (Helpers.IsClassic()) then

--- a/localisation/enGB.lua
+++ b/localisation/enGB.lua
@@ -252,3 +252,5 @@ L['Show Bottom Left Bar Text'] = true;
 L['Show Bottom Right Bar Text'] = true;
 L['Show Right 1 Bar Text'] = true;
 L['Show Right 2 Bar Text'] = true;
+
+L['Talking Head Frame'] = true;

--- a/modules/frames/talkinghead.lua
+++ b/modules/frames/talkinghead.lua
@@ -12,6 +12,7 @@ local dragFrame;
 
 function ImpUI_TalkingHead:Move()
     if (InCombatLockdown()) then return end
+    print('Moving');
 
     TalkingHeadFrame.ignoreFramePositionManager = true;
     TalkingHeadFrame:ClearAllPoints();
@@ -71,6 +72,8 @@ end
     @ return void
 ]]
 function ImpUI_TalkingHead:OnEnable()
+    if (Helpers.IsClassic()) then return end
+
     -- Create Drag Frame and load position.
     dragFrame = Helpers.create_drag_frame('ImpUI_TalkingHead_DragFrame', 300, 100, L['Talking Head Frame']);
 

--- a/modules/frames/talkinghead.lua
+++ b/modules/frames/talkinghead.lua
@@ -11,7 +11,11 @@ local L = LibStub('AceLocale-3.0'):GetLocale('ImprovedBlizzardUI');
 local dragFrame;
 
 function ImpUI_TalkingHead:Move()
-    print('Move');
+    if (InCombatLockdown()) then return end
+
+    TalkingHeadFrame.ignoreFramePositionManager = true;
+    TalkingHeadFrame:ClearAllPoints();
+    TalkingHeadFrame:SetPoint('CENTER', dragFrame, 'CENTER', 0, 0);
 end
 
 --[[
@@ -43,6 +47,16 @@ function ImpUI_TalkingHead:LoadPosition()
     dragFrame:SetPoint(pos.point, pos.relativeTo, pos.relativePoint, pos.x, pos.y);
 end
 
+
+--[[
+	Fires when the Player hits a loading screen / transition.
+	
+    @ return void
+]]
+function ImpUI_TalkingHead:PLAYER_ENTERING_WORLD()
+    ImpUI_TalkingHead:Move();
+end
+
 --[[
 	Fires when the module is Initialised.
 	
@@ -62,6 +76,8 @@ function ImpUI_TalkingHead:OnEnable()
 
     ImpUI_TalkingHead:LoadPosition();
     ImpUI_TalkingHead:Move();
+
+    self:RegisterEvent('PLAYER_ENTERING_WORLD');
 end
 
 --[[

--- a/modules/frames/talkinghead.lua
+++ b/modules/frames/talkinghead.lua
@@ -1,0 +1,73 @@
+--[[
+    modules\frames\talkinghead.lua
+    Simply adjusts the position of the Talking Head Frame.
+]]
+ImpUI_TalkingHead = ImpUI:NewModule('ImpUI_TalkingHead', 'AceEvent-3.0', 'AceHook-3.0');
+
+-- Get Locale
+local L = LibStub('AceLocale-3.0'):GetLocale('ImprovedBlizzardUI');
+
+-- Local Variables
+local dragFrame;
+
+function ImpUI_TalkingHead:Move()
+    print('Move');
+end
+
+--[[
+	Called when unlocking the UI.
+]]
+function ImpUI_TalkingHead:Unlock()
+    dragFrame:Show();
+end
+
+--[[
+	Called when locking the UI.
+]]
+function ImpUI_TalkingHead:Lock()
+    local point, relativeTo, relativePoint, xOfs, yOfs = dragFrame:GetPoint();
+
+    ImpUI.db.profile.talkingHeadPosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
+
+    dragFrame:Hide();
+end
+
+--[[
+	Loads the position of the Player Frame from SavedVariables.
+]]
+function ImpUI_TalkingHead:LoadPosition()
+    local pos = ImpUI.db.profile.talkingHeadPosition;
+    
+    -- Set Drag Frame Position
+    dragFrame:ClearAllPoints();
+    dragFrame:SetPoint(pos.point, pos.relativeTo, pos.relativePoint, pos.x, pos.y);
+end
+
+--[[
+	Fires when the module is Initialised.
+	
+    @ return void
+]]
+function ImpUI_TalkingHead:OnInitialize()
+end
+
+--[[
+	Fires when the module is Enabled. Set up frames, events etc here.
+	
+    @ return void
+]]
+function ImpUI_TalkingHead:OnEnable()
+    -- Create Drag Frame and load position.
+    dragFrame = Helpers.create_drag_frame('ImpUI_TalkingHead_DragFrame', 300, 100, L['Talking Head Frame']);
+
+    ImpUI_TalkingHead:LoadPosition();
+    ImpUI_TalkingHead:Move();
+end
+
+--[[
+	Clean up behind ourselves if needed.
+	
+    @ return void
+]]
+function ImpUI_TalkingHead:OnDisable()
+end

--- a/modules/frames/talkinghead.lua
+++ b/modules/frames/talkinghead.lua
@@ -12,7 +12,6 @@ local dragFrame;
 
 function ImpUI_TalkingHead:Move()
     if (InCombatLockdown()) then return end
-    print('Moving');
 
     TalkingHeadFrame.ignoreFramePositionManager = true;
     TalkingHeadFrame:ClearAllPoints();


### PR DESCRIPTION
I hate the position of the Talking Head frame by default so this simply moves it to the top of the screen by default. This has been marked as a draggable frame so if people get salty about it they can just move it.

Obviously this doesn't exist in classic so is just ignored there.

![WoWScrnShot_111220_163050](https://user-images.githubusercontent.com/7526918/98968726-ef9c6380-2505-11eb-973d-bd5758b1143c.jpg)
