### PR TITLE
Fixed Party Frames

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -54,30 +54,30 @@ ImpUI_Config.defaults = {
 
         performanceFrame = true,
         performanceFrameSize = 14,
-        performanceFramePosition = Helpers.pack_position('TOPRIGHT', nil, 'TOPRIGHT', -27.80, -9.40),
+        performanceFramePosition = Helpers.pack_position('TOPRIGHT', UIParent, 'TOPRIGHT', -27.80, -9.40),
 
-        osdPosition = Helpers.pack_position('CENTER', nil, 'CENTER', 0, 72),
-        killFeedPosition = Helpers.pack_position('TOPLEFT', nil, 'TOPLEFT', 8.33, -5),
+        osdPosition = Helpers.pack_position('CENTER', UIParent, 'CENTER', 0, 72),
+        killFeedPosition = Helpers.pack_position('TOPLEFT', UIParent, 'TOPLEFT', 8.33, -5),
 
         styleUnitFrames = true,
         
         playerFrameScale = 1.2,
-        playerFramePosition = Helpers.pack_position('CENTER', nil, 'CENTER', -305.16, -160.82),
+        playerFramePosition = Helpers.pack_position('CENTER', UIParent, 'CENTER', -305.16, -160.82),
         playerClassColours = true,
         playerHidePortraitSpam = true,
         playerHideOOC = true,
 
         targetFrameScale = 1.2,
-        targetFramePosition = Helpers.pack_position('CENTER', nil, 'CENTER', 305.16, -160.82),
+        targetFramePosition = Helpers.pack_position('CENTER', UIParent, 'CENTER', 305.16, -160.82),
         targetClassColours = true,
         targetBuffsOnTop = true,
         targetOfTargetClassColours = true,
 
         partyFrameScale = 1.4,
-        partyFramePosition = Helpers.pack_position('CENTER', nil, 'CENTER', -550, 100),
+        partyFramePosition = Helpers.pack_position('CENTER', UIParent, 'CENTER', -550, 100),
 
         focusFrameScale = 0.9,
-        focusFramePosition = Helpers.pack_position('CENTER', nil, 'CENTER', -500.0, -250.0),
+        focusFramePosition = Helpers.pack_position('CENTER', UIParent, 'CENTER', -500.0, -250.0),
         focusClassColours = true,
         focusBuffsOnTop = true,
 
@@ -104,13 +104,13 @@ ImpUI_Config.defaults = {
         tooltipItemRarity = true,
 
         castBarScale = 1.0,
-        castBarPosition = Helpers.pack_position('CENTER', nil, 'CENTER', 0, -175);
+        castBarPosition = Helpers.pack_position('CENTER', UIParent, 'CENTER', 0, -175);
         castBarPlayerTimer = true,
         castBarTargetTimer = true,
         castBarFocusTimer = true,
         castBarFontSize = 13,
 
-        buffsPosition = Helpers.pack_position('TOPRIGHT', nil, 'TOPRIGHT', -216, -34),
+        buffsPosition = Helpers.pack_position('TOPRIGHT', UIParent, 'TOPRIGHT', -216, -34),
         buffsScale = 1.1,
 
         microMenuFont = 'Improved Blizzard UI',
@@ -296,7 +296,7 @@ ImpUI_Config.options = {
                     type = 'header',
                     name = L['Party Frames'],
                     order = 11,
-                    hidden = true,
+                    hidden = false,
                 },
 
                 partyFrameScale = {
@@ -316,7 +316,7 @@ ImpUI_Config.options = {
                     end,
                     isPercent = false,
                     order = 12,
-                    hidden = true,
+                    hidden = false,
                 },
 
                 -- Focus Frames Section

--- a/core.lua
+++ b/core.lua
@@ -35,15 +35,12 @@ local function GetDraggables()
         'ImpUI_CastBar',
         'ImpUI_Buffs',
         'ImpUI_Performance',
+        'ImpUI_Party',
     };
 
     if (Helpers.IsRetail()) then
         table.insert(draggables, 'ImpUI_Focus');
         table.insert(draggables, 'ImpUI_TalkingHead');
-    end
-
-    if (Helpers.IsClassic() or Helpers.IsTBC()) then
-        table.insert(draggables, 'ImpUI_Party');
     end
 
     return draggables;

--- a/core.lua
+++ b/core.lua
@@ -139,7 +139,7 @@ function ImpUI:OnInitialize()
     LSM:Register(LSM.MediaType.FONT, 'Improved Blizzard UI', [[Interface\AddOns\ImprovedBlizzardUI\media\ImprovedBlizzardUI.ttf]]);
 
     -- Set up DB
-    self.db = LibStub('AceDB-3.0'):New('ImpUI_DB', ImpUI_Config.defaults, true);
+    self.db = LibStub('AceDB-3.0'):New('ImpBlizzardUI_DB', ImpUI_Config.defaults, true);
 
     -- Enable Profile Management
     ImpUI_Config.options.args.profile = LibStub("AceDBOptions-3.0"):GetOptionsTable(self.db);

--- a/helpers.lua
+++ b/helpers.lua
@@ -60,7 +60,7 @@ function Helpers.GetSupportedBuild()
     end
 
     if (Helpers.IsClassic()) then
-        return '1.13.6';
+        return '1.13.7';
     end
 end
 

--- a/modules/frames/party.lua
+++ b/modules/frames/party.lua
@@ -43,15 +43,21 @@ end
 	Loads the position of the Party Frames from SavedVariables.
 ]]
 function ImpUI_Party:LoadPosition()
-    -- Known issues moving party frames in retail.
-    if (Helpers.IsRetail() or Helpers.IsTBC()) then return end
-
     local pos = ImpUI.db.profile.partyFramePosition;
     local scale = ImpUI.db.profile.partyFrameScale;
     local offset = 0;
+
+    -- Fixes Set Anchor Point
+    if (pos.relativeTo == nil) then
+        pos.relativeTo = 'UIParent';
+    end
     
     -- Set Drag Frame Position
     dragFrame:SetPoint(pos.point, pos.relativeTo, pos.relativePoint, pos.x, pos.y);
+
+    -- Fixes Drag Frame
+    PartyMemberBackground:ClearAllPoints();
+    PartyMemberBackground:Hide();
 
     for i = 1, 4 do
         _G["PartyMemberFrame"..i]:SetMovable(true);
@@ -101,6 +107,11 @@ end
 function ImpUI_Party:Lock()
     local point, relativeTo, relativePoint, xOfs, yOfs = dragFrame:GetPoint();
 
+    -- Fixes Set Anchor Point
+    if (relativeTo == nil) then
+        relativeTo = 'UIParent';
+    end
+
     ImpUI.db.profile.partyFramePosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
 
     HideFrames();
@@ -122,12 +133,11 @@ end
     @ return void
 ]]
 function ImpUI_Party:OnEnable()
-    if (Helpers.IsRetail()) then return end
-
     -- Create Drag Frame and load position.
     dragFrame = Helpers.create_drag_frame('ImpUI_PartyFrame_DragFrame', 205, 350, L['Party Frames']);
 
     ImpUI_Party:LoadPosition();
+    ImpUI_Party:StyleFrames();
 end
 
 --[[

--- a/modules/frames/party.lua
+++ b/modules/frames/party.lua
@@ -29,13 +29,15 @@ function ImpUI_Party:StyleFrames()
         _G["PartyMemberFrame"..i.."Name"]:SetTextColor(font.r, font.g, font.b, font.a);
         _G["PartyMemberFrame"..i.."Name"]:SetFont(font.font, 10, font.flags);
         
-        _G["PartyMemberFrame"..i.."HealthBarText"]:SetFont(font.font, 8, font.flags);
-        _G["PartyMemberFrame"..i.."HealthBarTextLeft"]:SetFont(font.font, 8, font.flags);
-        _G["PartyMemberFrame"..i.."HealthBarTextRight"]:SetFont(font.font, 8, font.flags);
-
-        _G["PartyMemberFrame"..i.."ManaBarText"]:SetFont(font.font, 8, font.flags);
-        _G["PartyMemberFrame"..i.."ManaBarTextLeft"]:SetFont(font.font, 8, font.flags);
-        _G["PartyMemberFrame"..i.."ManaBarTextRight"]:SetFont(font.font, 8, font.flags);
+        if (Helpers.IsRetail()) then
+            _G["PartyMemberFrame"..i.."HealthBarText"]:SetFont(font.font, 8, font.flags);
+            _G["PartyMemberFrame"..i.."HealthBarTextLeft"]:SetFont(font.font, 8, font.flags);
+            _G["PartyMemberFrame"..i.."HealthBarTextRight"]:SetFont(font.font, 8, font.flags);
+    
+            _G["PartyMemberFrame"..i.."ManaBarText"]:SetFont(font.font, 8, font.flags);
+            _G["PartyMemberFrame"..i.."ManaBarTextLeft"]:SetFont(font.font, 8, font.flags);
+            _G["PartyMemberFrame"..i.."ManaBarTextRight"]:SetFont(font.font, 8, font.flags);
+        end
     end
 end
 


### PR DESCRIPTION
Special thanks to Meo and Dahk Celes from the WoWUIDev Discord.

- Fixes Anchor Point error for Party Frames in both Retail and TBC.
- Fixes Styling of Frames in Retail and TBC.
- Allows Drag and Drop placement in Classic Era, TBC and Retail.

The biggest downside however is I can't trust peoples SavedVariables from before this change so have to nuke the config DB and reset everyone back to Improved Blizzard UI defaults.

In both TBC and Classic Era the party frames with the default UI do not include Health and Mana text (much like the Player didn't in Classic Era).

I'd rather push this out then work on that seperately (if at all possible).